### PR TITLE
fixed adding same score after deleting same score

### DIFF
--- a/src/components/ScoreTable.tsx
+++ b/src/components/ScoreTable.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell, { tableCellClasses } from "@mui/material/TableCell";
@@ -49,8 +49,7 @@ const ScoreTable: FC = () => {
   const handleScoreInput = (event: any) => {
     // console.log(event);
     const enteredScore = event.target.value;
-    if (Number(enteredScore) < 0 || Number(enteredScore) > 15) return;
-    console.log(`enteredScore: ${enteredScore}`);
+    // console.log(`enteredScore: ${enteredScore}`);
     setScore(enteredScore);
   };
 


### PR DESCRIPTION
# Changes
* changed initial state of `score` to be `""` instead of `0`
* no longer resetting state to `0` on `handleSubmitScore`
* am now handling the score input as a `string` and then converting to a `number` when necessary (for calculations)